### PR TITLE
Ghoul FSM fully implemented with NewEnemy.cs, bug fixes done for enemy and player hitboxes and hurtboxes

### DIFF
--- a/2DRove/Assets/Animation/CagedSpiderAnimations/Caged Spider 43x19_0.controller.meta
+++ b/2DRove/Assets/Animation/CagedSpiderAnimations/Caged Spider 43x19_0.controller.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 10cab48a7471ecd4f904149dcb45f8c9
+guid: 14bd528fae06f8b46921048fbdb8a9b0
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 9100000

--- a/2DRove/Assets/Animation/CagedSpiderAnimations/Caged Spider.aseprite.meta
+++ b/2DRove/Assets/Animation/CagedSpiderAnimations/Caged Spider.aseprite.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 16c6be884a170514b82c3053d5ed53b2
+guid: 88de51f227c93e040875d5f2f12385b5
 ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/2DRove/Assets/Animation/Completed Animators/Ghoul.controller
+++ b/2DRove/Assets/Animation/Completed Animators/Ghoul.controller
@@ -197,7 +197,7 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 4
     m_ConditionEvent: velocity
-    m_EventTreshold: 0.001
+    m_EventTreshold: 0.0001
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 6947046724531018819}
   m_Solo: 0
@@ -429,7 +429,7 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 3
     m_ConditionEvent: velocity
-    m_EventTreshold: 0.001
+    m_EventTreshold: 0.0001
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -7452310233969898791}
   m_Solo: 0

--- a/2DRove/Assets/Animation/Completed Animators/Ghoul.controller
+++ b/2DRove/Assets/Animation/Completed Animators/Ghoul.controller
@@ -155,25 +155,25 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: attacking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: hit
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -335,7 +335,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 1
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/2DRove/Assets/Animation/GhoulAnimationAssets/GhoulAttack.anim
+++ b/2DRove/Assets/Animation/GhoulAnimationAssets/GhoulAttack.anim
@@ -47,8 +47,25 @@ AnimationClip:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -5176936615698939320, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: 3350677397565179862, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: -8324944260232109366, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: 8139043432225573482, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: 6918311515397744585, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: -1419006296698892175, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: 4429606571447898133, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: 4429606571447898133, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
@@ -73,4 +90,11 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0.21
+    functionName: EventTrigger
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/2DRove/Assets/Animation/GhoulAnimationAssets/GhoulHit.anim
+++ b/2DRove/Assets/Animation/GhoulAnimationAssets/GhoulHit.anim
@@ -81,4 +81,11 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0
+    functionName: TakeDamageAnimation
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/2DRove/Assets/Animation/GhoulAnimationAssets/GhoulHit.anim
+++ b/2DRove/Assets/Animation/GhoulAnimationAssets/GhoulHit.anim
@@ -41,8 +41,22 @@ AnimationClip:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -1238624536992928206, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: 7461289394191328812, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: -7991556346762831668, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: -3399689915215838967, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
+    - {fileID: -3399689915215838967, guid: dce3269edb161d8449c596d39fc459fc, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/2DRove/Assets/Penusbmic/11 DARK - Victorian Enemies & Assets/Enemies/Caged Spider 43x19_0.controller.meta
+++ b/2DRove/Assets/Penusbmic/11 DARK - Victorian Enemies & Assets/Enemies/Caged Spider 43x19_0.controller.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 10cab48a7471ecd4f904149dcb45f8c9
+guid: ad56204c0f09c6e4d9bd3e4ed3f6005d
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 9100000

--- a/2DRove/Assets/Penusbmic/11 DARK - Victorian Enemies & Assets/Enemies/Caged Spider.aseprite.meta
+++ b/2DRove/Assets/Penusbmic/11 DARK - Victorian Enemies & Assets/Enemies/Caged Spider.aseprite.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 16c6be884a170514b82c3053d5ed53b2
+guid: 069a637455c828f4d836c7f02c203b67
 ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/2DRove/Assets/Prefabs/CagedSpider.prefab
+++ b/2DRove/Assets/Prefabs/CagedSpider.prefab
@@ -14,6 +14,8 @@ GameObject:
   - component: {fileID: -150980145948101271}
   - component: {fileID: -7983308880637474554}
   - component: {fileID: 702997494839263448}
+  - component: {fileID: 2722715965370304581}
+  - component: {fileID: 8937932253450727748}
   m_Layer: 0
   m_Name: CagedSpider
   m_TagString: Untagged
@@ -31,8 +33,8 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 9.99, y: 9.99, z: 9.99}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -46,7 +48,7 @@ Animator:
   m_GameObject: {fileID: 7451212315464198201}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
+  m_Controller: {fileID: -3605996192705472802, guid: 16c6be884a170514b82c3053d5ed53b2, type: 3}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -106,7 +108,7 @@ SpriteRenderer:
   m_Size: {x: 0.11, y: 0.11}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!61 &-150980145948101271
@@ -141,7 +143,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0.004, y: 0.22}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.45454547, y: -1.4545455}
@@ -152,7 +154,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.0001, y: 0.0001}
+  m_Size: {x: 0.12, y: 0.14}
   m_EdgeRadius: 0
 --- !u!61 &-7983308880637474554
 BoxCollider2D:
@@ -186,7 +188,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0.004, y: 0.22}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.45454547, y: -1.4545455}
@@ -197,7 +199,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.0001, y: 0.0001}
+  m_Size: {x: 0.21, y: 0.11}
   m_EdgeRadius: 0
 --- !u!50 &702997494839263448
 Rigidbody2D:
@@ -212,9 +214,9 @@ Rigidbody2D:
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
   m_Mass: 1
-  m_LinearDrag: 0
+  m_LinearDrag: 10
   m_AngularDrag: 0.05
-  m_GravityScale: 1
+  m_GravityScale: 0
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -226,3 +228,29 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &2722715965370304581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7451212315464198201}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48ecf5e2f1d404a4fa35d95eca29e13f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8937932253450727748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7451212315464198201}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b43570ef5a6be954593f82aebdc41df0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 100
+  animator: {fileID: -4547627616058721799}

--- a/2DRove/Assets/Prefabs/Ghoul.prefab
+++ b/2DRove/Assets/Prefabs/Ghoul.prefab
@@ -181,6 +181,7 @@ GameObject:
   - component: {fileID: 5769794538153678791}
   - component: {fileID: 2563748308338659624}
   - component: {fileID: 962467841880699752}
+  - component: {fileID: 6891807063455474922}
   m_Layer: 7
   m_Name: Ghoul
   m_TagString: Enemy
@@ -202,7 +203,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3676918177868209009}
-  - {fileID: 5893204250632373386}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &878488624133352400
@@ -310,7 +310,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.0051591704, y: 0.12500592}
+  m_Offset: {x: 0.007119829, y: 0.12500592}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.44444442, y: -0.04347826}
@@ -321,7 +321,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.069776654, y: 0.23010108}
+  m_Size: {x: 0.09433465, y: 0.23010108}
   m_EdgeRadius: 0
 --- !u!50 &-1127995572195980354
 Rigidbody2D:
@@ -362,6 +362,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e9468a1e7eb719b4cb2f0380bd8eb3c6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  animator: {fileID: 0}
 --- !u!61 &2563748308338659624
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -369,7 +370,7 @@ BoxCollider2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3475996137607520006}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -394,7 +395,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.13075925}
+  m_Offset: {x: 0.13556303, y: 0.13075925}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.44444442, y: -0.04347826}
@@ -405,7 +406,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.53, y: 0.14}
+  m_Size: {x: 0.25982478, y: 0.14000002}
   m_EdgeRadius: 0
 --- !u!114 &962467841880699752
 MonoBehaviour:
@@ -420,56 +421,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 100
-  animator: {fileID: 0}
---- !u!1 &3921996220012240833
-GameObject:
+  animator: {fileID: 878488624133352400}
+--- !u!70 &6891807063455474922
+CapsuleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5893204250632373386}
-  - component: {fileID: 46054970155611650}
-  - component: {fileID: 7431076521784452740}
-  m_Layer: 7
-  m_Name: AttackBox
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5893204250632373386
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3921996220012240833}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4012842002547039159}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &46054970155611650
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3921996220012240833}
+  m_GameObject: {fileID: 3475996137607520006}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 64
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 439
   m_LayerOverridePriority: 0
   m_ForceSendLayers:
     serializedVersion: 2
@@ -486,33 +454,9 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.13075925}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.53, y: 0.14}
-  m_EdgeRadius: 0
---- !u!114 &7431076521784452740
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3921996220012240833}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b43570ef5a6be954593f82aebdc41df0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxHealth: 100
-  animator: {fileID: 0}
+  m_Offset: {x: 0.09993597, y: 0.13000052}
+  m_Size: {x: 0.23485553, y: 0.16749361}
+  m_Direction: 1
 --- !u!1 &4951135885874391136
 GameObject:
   m_ObjectHideFlags: 0
@@ -695,8 +639,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -0.008, y: 0.106}
-  m_SizeDelta: {x: 6.4348, y: 1.1157}
+  m_AnchoredPosition: {x: -0.01084, y: 0.13245}
+  m_SizeDelta: {x: 2.05634, y: 0.97673}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &5904735019844170611
 Canvas:

--- a/2DRove/Assets/Prefabs/Player.prefab
+++ b/2DRove/Assets/Prefabs/Player.prefab
@@ -195,19 +195,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d65af4b292c6b6e4583fa4245458c416, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  health: 10
+  health: 100
   maxHealth: 10
   coins: 0
   speedFactor: 50
   blinkDistance: 5
   blinkCooldown: 1
   shootCooldown: 1
-  projectilePrefab: {fileID: 3833847839207358409, guid: d3594913b3b82534c89d435f6cf70cb3, type: 3}
+  projectilePrefab: {fileID: 9032579860153729722, guid: fccb1090956a9804b86ef8c349819aeb, type: 3}
   slashPoint: {fileID: 8752092245281292779}
   slashRange: 1.5
   enemyLayer:
     serializedVersion: 2
     m_Bits: 128
+  knockbackStrength: 5
 --- !u!114 &3614290600010504197
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -262,7 +263,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8064289160981386832}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.21, y: -0.025999999, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0}
   m_ConstrainProportionsScale: 0

--- a/2DRove/Assets/Prefabs/Spitter.prefab
+++ b/2DRove/Assets/Prefabs/Spitter.prefab
@@ -114,7 +114,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1758016283059345825
 Transform:
   m_ObjectHideFlags: 0

--- a/2DRove/Assets/Scenes/Level_00.unity
+++ b/2DRove/Assets/Scenes/Level_00.unity
@@ -265,97 +265,9 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 46054970155611650, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 272362257799738756, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_Size.x
-      value: 0.09433465
-      objectReference: {fileID: 0}
-    - target: {fileID: 272362257799738756, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 272362257799738756, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_Offset.x
-      value: 0.007119829
-      objectReference: {fileID: 0}
-    - target: {fileID: 962467841880699752, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: animator
-      value: 
-      objectReference: {fileID: 2139139839}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_Size.x
-      value: 0.25982478
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_Size.y
-      value: 0.14000002
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_Offset.x
-      value: 0.13556303
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_Offset.y
-      value: 0.13075925
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_SpriteTilingProperty.pivot.x
-      value: 0.23076925
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_SpriteTilingProperty.pivot.y
-      value: -0.045454547
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_SpriteTilingProperty.newSize.x
-      value: 0.14
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_SpriteTilingProperty.newSize.y
-      value: 0.21
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_SpriteTilingProperty.oldSize.x
-      value: 0.39
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_SpriteTilingProperty.oldSize.y
-      value: 0.22
-      objectReference: {fileID: 0}
-    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_SpriteTilingProperty.adaptiveTilingThreshold
-      value: 0.5
-      objectReference: {fileID: 0}
     - target: {fileID: 3475996137607520006, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_Name
       value: Ghoul
-      objectReference: {fileID: 0}
-    - target: {fileID: 3475996137607520006, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_TagString
-      value: Enemy
-      objectReference: {fileID: 0}
-    - target: {fileID: 3676918177868209009, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 2.05634
-      objectReference: {fileID: 0}
-    - target: {fileID: 3676918177868209009, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0.97673
-      objectReference: {fileID: 0}
-    - target: {fileID: 3676918177868209009, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -0.01084
-      objectReference: {fileID: 0}
-    - target: {fileID: 3676918177868209009, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0.13245
       objectReference: {fileID: 0}
     - target: {fileID: 4012842002547039159, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -397,16 +309,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 0}
-    - {fileID: 7431076521784452740, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-    m_RemovedGameObjects:
-    - {fileID: 3921996220012240833, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3475996137607520006, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2139139847}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
 --- !u!1 &263697363
 GameObject:
@@ -692,47 +598,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &457830596 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7451212315464198201, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-  m_PrefabInstance: {fileID: 1153652336}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &457830597
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 457830596}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 48ecf5e2f1d404a4fa35d95eca29e13f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!95 &457830602 stripped
-Animator:
-  m_CorrespondingSourceObject: {fileID: -4547627616058721799, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-  m_PrefabInstance: {fileID: 1153652336}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &457830604
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 457830596}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b43570ef5a6be954593f82aebdc41df0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxHealth: 100
-  animator: {fileID: 457830602}
---- !u!1 &476245495 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3475996137607520006, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-  m_PrefabInstance: {fileID: 253213109}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &550893384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1270,11 +1135,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1784697184544801091, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 6.52
       objectReference: {fileID: 0}
     - target: {fileID: 1784697184544801091, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -8.51
+      value: 0.86
       objectReference: {fileID: 0}
     - target: {fileID: 1784697184544801091, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1311,42 +1176,6 @@ PrefabInstance:
     - target: {fileID: 6916207954854211963, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
       propertyPath: m_Name
       value: Player
-      objectReference: {fileID: 0}
-    - target: {fileID: 8181783134252115575, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
-      propertyPath: health
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 8181783134252115575, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
-      propertyPath: projectilePrefab
-      value: 
-      objectReference: {fileID: 9032579860153729722, guid: fccb1090956a9804b86ef8c349819aeb, type: 3}
-    - target: {fileID: 8752092245281292779, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8752092245281292779, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.21
-      objectReference: {fileID: 0}
-    - target: {fileID: 8752092245281292779, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8752092245281292779, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8752092245281292779, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8752092245281292779, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8752092245281292779, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1730,73 +1559,9 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: -7983308880637474554, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Size.x
-      value: 0.21
-      objectReference: {fileID: 0}
-    - target: {fileID: -7983308880637474554, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Size.y
-      value: 0.11
-      objectReference: {fileID: 0}
-    - target: {fileID: -7983308880637474554, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Offset.x
-      value: 0.004
-      objectReference: {fileID: 0}
-    - target: {fileID: -7983308880637474554, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Offset.y
-      value: 0.22
-      objectReference: {fileID: 0}
-    - target: {fileID: -4547627616058721799, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: -3605996192705472802, guid: 16c6be884a170514b82c3053d5ed53b2, type: 3}
-    - target: {fileID: -150980145948101271, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Size.x
-      value: 0.12
-      objectReference: {fileID: 0}
-    - target: {fileID: -150980145948101271, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Size.y
-      value: 0.14
-      objectReference: {fileID: 0}
-    - target: {fileID: -150980145948101271, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Offset.x
-      value: 0.004
-      objectReference: {fileID: 0}
-    - target: {fileID: -150980145948101271, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Offset.y
-      value: 0.22
-      objectReference: {fileID: 0}
-    - target: {fileID: 702997494839263448, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_Mass
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 702997494839263448, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_LinearDrag
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 702997494839263448, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_GravityScale
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 7451212315464198201, guid: c784912f46a7eef43883c17e90185d08, type: 3}
       propertyPath: m_Name
       value: CagedSpider
-      objectReference: {fileID: 0}
-    - target: {fileID: 7451212315464198201, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8191069111030342767, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 9.99
-      objectReference: {fileID: 0}
-    - target: {fileID: 8191069111030342767, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 9.99
-      objectReference: {fileID: 0}
-    - target: {fileID: 8191069111030342767, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 9.99
       objectReference: {fileID: 0}
     - target: {fileID: 8191069111030342767, guid: c784912f46a7eef43883c17e90185d08, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1838,20 +1603,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8191069111030342767, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      propertyPath: m_ConstrainProportionsScale
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 7451212315464198201, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 457830597}
-    - targetCorrespondingSourceObject: {fileID: 7451212315464198201, guid: c784912f46a7eef43883c17e90185d08, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 457830604}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c784912f46a7eef43883c17e90185d08, type: 3}
 --- !u!1 &1261592505
 GameObject:
@@ -1982,24 +1737,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Spitter
       objectReference: {fileID: 0}
-    - target: {fileID: 6229290378130564962, guid: be179befa880d774ea3885548de8a42e, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7350636726140891444, guid: be179befa880d774ea3885548de8a42e, type: 3}
-      propertyPath: animator
-      value: 
-      objectReference: {fileID: 1311096808}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: be179befa880d774ea3885548de8a42e, type: 3}
---- !u!95 &1311096808 stripped
-Animator:
-  m_CorrespondingSourceObject: {fileID: -2934730531895897082, guid: be179befa880d774ea3885548de8a42e, type: 3}
-  m_PrefabInstance: {fileID: 1311096807}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1374899003
 GameObject:
   m_ObjectHideFlags: 0
@@ -3005,46 +2747,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2101556889}
   m_CullTransparentMesh: 1
---- !u!95 &2139139839 stripped
-Animator:
-  m_CorrespondingSourceObject: {fileID: 878488624133352400, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-  m_PrefabInstance: {fileID: 253213109}
-  m_PrefabAsset: {fileID: 0}
---- !u!70 &2139139847
-CapsuleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 476245495}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 64
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 439
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.09993597, y: 0.13000052}
-  m_Size: {x: 0.23485553, y: 0.16749361}
-  m_Direction: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/2DRove/Assets/Scenes/Level_00.unity
+++ b/2DRove/Assets/Scenes/Level_00.unity
@@ -265,9 +265,17 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 46054970155611650, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 272362257799738756, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_Size.x
       value: 0.09433465
+      objectReference: {fileID: 0}
+    - target: {fileID: 272362257799738756, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 272362257799738756, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_Offset.x
@@ -278,12 +286,52 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2139139839}
     - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_Size.x
+      value: 0.25982478
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_Size.y
-      value: 0.2356213
+      value: 0.14000002
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.13556303
       objectReference: {fileID: 0}
     - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_Offset.y
-      value: 0.12591298
+      value: 0.13075925
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_SpriteTilingProperty.pivot.x
+      value: 0.23076925
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_SpriteTilingProperty.pivot.y
+      value: -0.045454547
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_SpriteTilingProperty.newSize.x
+      value: 0.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_SpriteTilingProperty.newSize.y
+      value: 0.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_SpriteTilingProperty.oldSize.x
+      value: 0.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_SpriteTilingProperty.oldSize.y
+      value: 0.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563748308338659624, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+      propertyPath: m_SpriteTilingProperty.adaptiveTilingThreshold
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 3475996137607520006, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_Name
@@ -311,11 +359,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4012842002547039159, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -3.51
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4012842002547039159, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.04
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4012842002547039159, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       propertyPath: m_LocalPosition.z
@@ -352,12 +400,13 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 0}
     - {fileID: 7431076521784452740, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 3921996220012240833, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3921996220012240833, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+    - targetCorrespondingSourceObject: {fileID: 3475996137607520006, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1152047502}
+      addedObject: {fileID: 2139139847}
   m_SourcePrefab: {fileID: 100100000, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
 --- !u!1 &263697363
 GameObject:
@@ -679,6 +728,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxHealth: 100
   animator: {fileID: 457830602}
+--- !u!1 &476245495 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3475996137607520006, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
+  m_PrefabInstance: {fileID: 253213109}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &550893384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1220,7 +1274,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1784697184544801091, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -8.51
       objectReference: {fileID: 0}
     - target: {fileID: 1784697184544801091, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1257,6 +1311,10 @@ PrefabInstance:
     - target: {fileID: 6916207954854211963, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
       propertyPath: m_Name
       value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 8181783134252115575, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
+      propertyPath: health
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 8181783134252115575, guid: 40c84a5918b26d04e9f342e9cbc35447, type: 3}
       propertyPath: projectilePrefab
@@ -1664,25 +1722,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1014281881}
   m_CullTransparentMesh: 1
---- !u!1 &1152047499 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3921996220012240833, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
-  m_PrefabInstance: {fileID: 253213109}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1152047502
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1152047499}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b43570ef5a6be954593f82aebdc41df0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxHealth: 100
-  animator: {fileID: 2139139839}
 --- !u!1001 &1153652336
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1742,6 +1781,10 @@ PrefabInstance:
     - target: {fileID: 7451212315464198201, guid: c784912f46a7eef43883c17e90185d08, type: 3}
       propertyPath: m_Name
       value: CagedSpider
+      objectReference: {fileID: 0}
+    - target: {fileID: 7451212315464198201, guid: c784912f46a7eef43883c17e90185d08, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8191069111030342767, guid: c784912f46a7eef43883c17e90185d08, type: 3}
       propertyPath: m_LocalScale.x
@@ -1938,6 +1981,10 @@ PrefabInstance:
     - target: {fileID: 6229290378130564962, guid: be179befa880d774ea3885548de8a42e, type: 3}
       propertyPath: m_Name
       value: Spitter
+      objectReference: {fileID: 0}
+    - target: {fileID: 6229290378130564962, guid: be179befa880d774ea3885548de8a42e, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7350636726140891444, guid: be179befa880d774ea3885548de8a42e, type: 3}
       propertyPath: animator
@@ -2963,6 +3010,41 @@ Animator:
   m_CorrespondingSourceObject: {fileID: 878488624133352400, guid: a9092d72cc10e4343a152466830e5b3b, type: 3}
   m_PrefabInstance: {fileID: 253213109}
   m_PrefabAsset: {fileID: 0}
+--- !u!70 &2139139847
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476245495}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 64
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 439
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.09993597, y: 0.13000052}
+  m_Size: {x: 0.23485553, y: 0.16749361}
+  m_Direction: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -2974,3 +3056,4 @@ SceneRoots:
   - {fileID: 253213109}
   - {fileID: 741563902}
   - {fileID: 1311096807}
+  - {fileID: 1153652336}

--- a/2DRove/Assets/Scripts/NewEnemy.cs
+++ b/2DRove/Assets/Scripts/NewEnemy.cs
@@ -24,28 +24,16 @@ public class NewEnemy : MonoBehaviour
     {
         currentHealth -= damage;
         animator.SetTrigger("hit");
-        if (currentHealth <= 0)
-        {
-            Die();
-        }
     }
 
     public void TakeRangedDamage(float rangedDamage)
     {
         currentHealth -= rangedDamage;
         animator.SetTrigger("hit");
-        if (currentHealth <= 0)
-        {
-            Die();
-        }
     }
-
-    void Die()
+    
+    public float CurrentHeath()
     {
-        animator.SetBool("isDead", true);
-        GetComponent<Collider2D>().enabled = false;
-        this.enabled = false;
-        // wait for 1 second
-        Destroy(gameObject, 1f);
+        return currentHealth;
     }
 }

--- a/2DRove/Assets/Scripts/PlayerController.cs
+++ b/2DRove/Assets/Scripts/PlayerController.cs
@@ -172,6 +172,7 @@ public class PlayerController : MonoBehaviour
         Collider2D[] hitEnemies = Physics2D.OverlapCircleAll(slashPoint.position, slashRange, enemyLayer);
         foreach (Collider2D enemy in hitEnemies) {
             NewEnemy enemyScript = enemy.GetComponent<NewEnemy>();
+            
             if (enemyScript != null) {
                 enemyScript.TakeDamage(playerAttackDamage);
                 Rigidbody2D enemyRb = enemy.GetComponent<Rigidbody2D>();

--- a/2DRove/Assets/Scripts/PlayerController.cs
+++ b/2DRove/Assets/Scripts/PlayerController.cs
@@ -170,7 +170,11 @@ public class PlayerController : MonoBehaviour
     private void ApplyDamage() {
         Vector2 knockbackDirection = (Vector2)(transform.position - slashPoint.position).normalized;
         Collider2D[] hitEnemies = Physics2D.OverlapCircleAll(slashPoint.position, slashRange, enemyLayer);
+        //PROBLEM, THIS HITBOX DETECTION APPLIES TO ENEMY HITBOX AS WELL, NOT JUST THEIR BODY HURTBOX
+        //Current fix, only look for box colliders, as current hitboxes for enemies are capsules, while their hurtbox are boxcolliders
         foreach (Collider2D enemy in hitEnemies) {
+            if (enemy is not BoxCollider2D)
+                continue;
             NewEnemy enemyScript = enemy.GetComponent<NewEnemy>();
             
             if (enemyScript != null) {

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulAggroState.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulAggroState.cs
@@ -30,7 +30,7 @@ public class GhoulAggroState : GhoulBaseState
 
     public override void OnCollisionEnter2D(GhoulStateManager ghoul, Collision2D other)
     {
-
+        
     }
 
     public override void OnTriggerStay2D(GhoulStateManager ghoul, Collider2D other) {
@@ -38,5 +38,15 @@ public class GhoulAggroState : GhoulBaseState
         {
             ghoul.SwitchState(ghoul.AttackState);
         }
+    }
+
+    public override void EventTrigger(GhoulStateManager ghoul)
+    {
+
+    }
+
+    public override void TakeDamage(GhoulStateManager ghoul)
+    {
+        ghoul.SwitchState(ghoul.HitState);
     }
 }

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulAttackState.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulAttackState.cs
@@ -28,6 +28,31 @@ public class GhoulAttackState : GhoulBaseState
         
     }
     
-    public override void OnTriggerStay2D(GhoulStateManager ghoul, Collider2D other) {
+    public override void OnTriggerStay2D(GhoulStateManager ghoul, Collider2D other) 
+    {
+
+    }
+
+    //done in animation events
+    public override void EventTrigger(GhoulStateManager ghoul)
+    {
+        CapsuleCollider2D hitbox = ghoul.GetComponent<CapsuleCollider2D>();
+        Vector2 worldSpace = new Vector2(ghoul.GetComponent<Transform>().position.x + 1.1f, ghoul.GetComponent<Transform>().position.y + 1.15f);
+        LayerMask mask = LayerMask.GetMask("Player");
+        Collider2D[] colliders = Physics2D.OverlapCapsuleAll(worldSpace + hitbox.offset, new Vector2(2.1f, 1.75f), CapsuleDirection2D.Horizontal, 0f, mask);
+
+        foreach (Collider2D collider in colliders)
+        {
+            if (collider.CompareTag("Player"))
+            {
+                PlayerController playerScript = collider.GetComponent<PlayerController>();
+                playerScript.dealDamage(1);
+            }
+        }
+    }
+
+    public override void TakeDamage(GhoulStateManager ghoul)
+    {
+        ghoul.SwitchState(ghoul.HitState);
     }
 }

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulBaseState.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulBaseState.cs
@@ -6,4 +6,6 @@ public abstract class GhoulBaseState
     public abstract void UpdateState(GhoulStateManager ghoul);
     public abstract void OnCollisionEnter2D(GhoulStateManager ghoul, Collision2D other);
     public abstract void OnTriggerStay2D(GhoulStateManager ghoul, Collider2D other);
+    public abstract void EventTrigger(GhoulStateManager ghoul);
+    public abstract void TakeDamage(GhoulStateManager ghoul);
 }

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulDeathState.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulDeathState.cs
@@ -6,6 +6,12 @@ public class GhoulDeathState : GhoulBaseState
     public override void EnterState(GhoulStateManager ghoul)
     {
         Debug.Log("Entering Death State...");
+        ghoul.animator.SetBool("isDead", true);
+        ghoul.GetComponent<Collider2D>().enabled = false;
+        // ghoul.GetComponent<CapsuleCollider2D>().enabled = false;
+        ghoul.enabled = false;
+        // wait for 1 second
+        ghoul.Destroy(.81f);
     }
 
     public override void UpdateState(GhoulStateManager ghoul)
@@ -28,6 +34,6 @@ public class GhoulDeathState : GhoulBaseState
 
     public override void TakeDamage(GhoulStateManager ghoul)
     {
-        ghoul.SwitchState(ghoul.HitState);
+
     }
 }

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulDeathState.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulDeathState.cs
@@ -2,9 +2,10 @@ using UnityEngine;
 
 public class GhoulDeathState : GhoulBaseState
 {
+    
     public override void EnterState(GhoulStateManager ghoul)
     {
-
+        Debug.Log("Entering Death State...");
     }
 
     public override void UpdateState(GhoulStateManager ghoul)
@@ -18,5 +19,15 @@ public class GhoulDeathState : GhoulBaseState
     }
 
     public override void OnTriggerStay2D(GhoulStateManager ghoul, Collider2D other) {
+    }
+
+    public override void EventTrigger(GhoulStateManager ghoul)
+    {
+
+    }
+
+    public override void TakeDamage(GhoulStateManager ghoul)
+    {
+        ghoul.SwitchState(ghoul.HitState);
     }
 }

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulHitState.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulHitState.cs
@@ -2,14 +2,24 @@ using UnityEngine;
 
 public class GhoulHitState : GhoulBaseState
 {
+    private Animator animator;
+    private float hitStun = .41f;
     public override void EnterState(GhoulStateManager ghoul)
     {
-
+        Debug.Log("Entering Hit State...");
+        animator = ghoul.GetComponent<Animator>();
+        //set animation bool hitstunn to true or smth
+        animator.SetTrigger("hit");
     }
 
     public override void UpdateState(GhoulStateManager ghoul)
     {
+        if (hitStun <= 0)
+        {
+            ghoul.SwitchState(ghoul.IdleState);
+        }
 
+        hitStun -= Time.deltaTime;
     }
 
     public override void OnCollisionEnter2D(GhoulStateManager ghoul, Collision2D other)
@@ -18,5 +28,15 @@ public class GhoulHitState : GhoulBaseState
     } 
 
     public override void OnTriggerStay2D(GhoulStateManager ghoul, Collider2D other) {
+    }
+
+    public override void EventTrigger(GhoulStateManager ghoul)
+    {
+
+    }
+
+    public override void TakeDamage(GhoulStateManager ghoul)
+    {
+        ghoul.SwitchState(ghoul.HitState);
     }
 }

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulHitState.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulHitState.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 public class GhoulHitState : GhoulBaseState
 {
+    private float health;
     private Animator animator;
     private float hitStun = .41f;
     public override void EnterState(GhoulStateManager ghoul)
@@ -9,7 +10,14 @@ public class GhoulHitState : GhoulBaseState
         Debug.Log("Entering Hit State...");
         animator = ghoul.GetComponent<Animator>();
         //set animation bool hitstunn to true or smth
-        animator.SetTrigger("hit");
+        // NO NEED TO SET TRIGGER bc its done in NewEnemy for now
+        // animator.SetTrigger("hit");
+
+        health = ghoul.GetComponent<NewEnemy>().CurrentHeath();
+        if (health <= 0)
+        {
+            ghoul.SwitchState(ghoul.DeathState);
+        }
     }
 
     public override void UpdateState(GhoulStateManager ghoul)

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulIdleState.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulIdleState.cs
@@ -7,7 +7,7 @@ public class GhoulIdleState : GhoulBaseState
     private Transform player;
     public override void EnterState(GhoulStateManager ghoul)
     {
-        Debug.Log("Entering Wake State...");
+        Debug.Log("Entering Idle State...");
         player = GameObject.FindGameObjectWithTag("Player").GetComponent<Transform>();
     }
 
@@ -25,5 +25,15 @@ public class GhoulIdleState : GhoulBaseState
     } 
 
     public override void OnTriggerStay2D(GhoulStateManager ghoul, Collider2D other) {
+    }
+
+    public override void EventTrigger(GhoulStateManager ghoul)
+    {
+
+    }
+
+    public override void TakeDamage(GhoulStateManager ghoul)
+    {
+        ghoul.SwitchState(ghoul.HitState);
     }
 }

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulSpawnState.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulSpawnState.cs
@@ -24,10 +24,16 @@ public class GhoulSpawnState : GhoulBaseState
     } 
 
     public override void OnTriggerStay2D(GhoulStateManager ghoul, Collider2D other) {
-        Debug.Log(other.tag);
-        if (other.tag == "Player")
-        {
-            ghoul.SwitchState(ghoul.AttackState);
-        }
+        
+    }
+
+    public override void EventTrigger(GhoulStateManager ghoul)
+    {
+
+    }
+
+    public override void TakeDamage(GhoulStateManager ghoul)
+    {
+        ghoul.SwitchState(ghoul.HitState);
     }
 }

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulStateManager.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulStateManager.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class GhoulStateManager : MonoBehaviour
 {
+    private Animator animator;
     GhoulBaseState currentState;
     public GhoulAggroState AggroState = new GhoulAggroState();
     public GhoulAttackState AttackState = new GhoulAttackState();
@@ -17,6 +18,7 @@ public class GhoulStateManager : MonoBehaviour
     {
         currentState = SpawnState;
         currentState.EnterState(this);
+        animator = this.GetComponent<Animator>();
     }
 
     // Update is called once per frame
@@ -33,5 +35,17 @@ public class GhoulStateManager : MonoBehaviour
     {
         currentState = state;
         state.EnterState(this);
+    }
+
+    public void EventTrigger()
+    {
+        currentState.EventTrigger(this);
+    }
+
+//damage dealt is calculated by PlayerController.cs
+//this is purely to be placed in hit stun
+    public void TakeDamageAnimation()
+    {
+        currentState.TakeDamage(this);
     }
 }

--- a/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulStateManager.cs
+++ b/2DRove/Assets/Scripts/StateMachines/GhoulFSM/GhoulStateManager.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class GhoulStateManager : MonoBehaviour
 {
-    private Animator animator;
+    public Animator animator;
     GhoulBaseState currentState;
     public GhoulAggroState AggroState = new GhoulAggroState();
     public GhoulAttackState AttackState = new GhoulAttackState();
@@ -47,5 +47,10 @@ public class GhoulStateManager : MonoBehaviour
     public void TakeDamageAnimation()
     {
         currentState.TakeDamage(this);
+    }
+
+    public void Destroy(float waitDuration)
+    {
+        Destroy(gameObject, waitDuration);
     }
 }


### PR DESCRIPTION
FSM Notes -
- Ghoul FSM completed for now
- potential revamping in the future if enough time
- other FSMs need minor adjustments
The finite state machine has been fully implemented for the ghoul, which some minor changes need to be made to the other FSMs as well. The current version for the FSM works as intended, increasing its efficiency and being able to spawn 50% more mobs than without the FSM, however the implementation as to how it was done could be improved. If given the time, the FSM should be reorganized to potentially omit the NewEnemy script, or having it so that it runs along side the NewEnemy script exclusively for animations, moving the mechanical aspect of the enemy to be in the NewEnemy script (would require a unique NewEnemy script per enemy, so this revamp may not be too possible given time contraints). In the end, it works much better before.

Enemy Notes -
- IMPORTANT: Enemy hurtbox should be the BoxCollider2D, enemy hitbox should be capsules, explained further in player notes
- Added capability for enemy to do damage to the player using animation events

Player Notes -
- as to how damage is currently implemented in PlayerController.cs in ApplyDamage(), player swings at ANY Collider, including enemy hitboxes.
- Fastest solution was to separate Box colliders and capsule colliders in to hurtbox and hitbox respectively
- if you have a better way of implementing, notify us to change this standard
- Best solution possible, dynamic hitboxes that potentially morph with attack animation, but that would probably be rough.