### PR TITLE
Implemented border generation around tiles

### DIFF
--- a/2DRove/Assets/Maps/Floor1.unity
+++ b/2DRove/Assets/Maps/Floor1.unity
@@ -389,9 +389,6 @@ MonoBehaviour:
   playerInput: {fileID: 409696410}
   sprintSpeed: 50
   moveSpeed: 30
-  tileLayer:
-    serializedVersion: 2
-    m_Bits: 0
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -542,6 +539,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   tile: {fileID: 9148618936101596910, guid: 1229179fec04ecb47bd1add17e053ab4, type: 3}
+  borderPrefab: {fileID: 9148618936101596910, guid: 0782699ad0b610845b181582b233c853, type: 3}
   tileNum: 20
   scale: 2
   maxX: 5

--- a/2DRove/Assets/Scripts/MapGenDLA.cs
+++ b/2DRove/Assets/Scripts/MapGenDLA.cs
@@ -154,12 +154,13 @@ namespace MapGenDLA
                 Mathf.Max returns the larger of the two numbers
                 Example: Mathf.Min(5, 10) returns 5
             */
+            int distance = 1;
             switch (direction)
             {
-                case 0: return new Vector2Int(Mathf.Clamp(position.x + 1,minX, maxX), Mathf.Clamp(position.y+1, minY, maxY));//ur
-                case 1: return new Vector2Int(Mathf.Clamp(position.x - 1, minX, maxX), Mathf.Clamp(position.y-1, minY, maxY));//dl
-                case 2: return new Vector2Int(Mathf.Clamp(position.x-1, minX, maxX), Mathf.Clamp(position.y + 1, minY, maxY));//ul
-                case 3: return new Vector2Int(Mathf.Clamp(position.x+1, minX, maxX), Mathf.Clamp(position.y - 1, minY, maxY));//dr
+                case 0: return new Vector2Int(Mathf.Clamp(position.x + distance,minX, maxX), Mathf.Clamp(position.y + distance, minY, maxY));//ur
+                case 1: return new Vector2Int(Mathf.Clamp(position.x - distance, minX, maxX), Mathf.Clamp(position.y - distance, minY, maxY));//dl
+                case 2: return new Vector2Int(Mathf.Clamp(position.x - distance, minX, maxX), Mathf.Clamp(position.y + distance, minY, maxY));//ul
+                case 3: return new Vector2Int(Mathf.Clamp(position.x + distance, minX, maxX), Mathf.Clamp(position.y - distance, minY, maxY));//dr
 
                 default: return position;
             }
@@ -177,27 +178,29 @@ namespace MapGenDLA
 
         }
 
+
+        // Deprecated for now.
         // Fills in the empty space created between tiles and the border similarly to tile generation. 
-        void FillInEmptySpace()
-        {
-            // Generate empty space
-            for (int i = minX-1; i <= maxX+1; i++)
-                for (int j = minY-1; j <= maxY+1; j++)
-                {
-                    Debug.Log("Generating empty space for: " + i + " " + j);
-                    // Check if the position is already occupied
-                    if (!tilePositions.Contains(new Vector2Int(i, j)))
-                    {
-                        GameObject emptyTiles = Instantiate(tile, new Vector3(i * scale*10, j * scale*5, 0), Quaternion.identity);
-                        emptyTiles.name = "EmptyTile(" + i + ", " + j + ")";
-                        emptyTiles.transform.localScale = new Vector3(scale, scale, 1);
-                        emptyTiles.GetComponent<SpriteRenderer>().color = Color.black;
-                        emptyTiles.AddComponent<BoxCollider2D>();
-                        tilePositions.Add(new Vector2Int(i, j));
-                    }
-                }
-            Debug.Log("Empty Space generated: " + tilePositions.Count);
-        }
+        // void FillInEmptySpace()
+        // {
+        //     // Generate empty space
+        //     for (int i = minX-1; i <= maxX+1; i++)
+        //         for (int j = minY-1; j <= maxY+1; j++)
+        //         {
+        //             Debug.Log("Generating empty space for: " + i + " " + j);
+        //             // Check if the position is already occupied
+        //             if (!tilePositions.Contains(new Vector2Int(i, j)))
+        //             {
+        //                 GameObject emptyTiles = Instantiate(tile, new Vector3(i * scale*10, j * scale*5, 0), Quaternion.identity);
+        //                 emptyTiles.name = "EmptyTile(" + i + ", " + j + ")";
+        //                 emptyTiles.transform.localScale = new Vector3(scale, scale, 1);
+        //                 emptyTiles.GetComponent<SpriteRenderer>().color = Color.black;
+        //                 emptyTiles.AddComponent<BoxCollider2D>();
+        //                 tilePositions.Add(new Vector2Int(i, j));
+        //             }
+        //         }
+        //     Debug.Log("Empty Space generated: " + tilePositions.Count);
+        // }
 
         
 


### PR DESCRIPTION
Fixed the methodology to generate borders in empty spaces around our tiles. There is still an issue with how our DLA generates tiles that overlap that creates some border tiles on our map. Will make this a pull request and open an issue to try and fix this.

![image](https://github.com/UNLV-CS472-672/2024-S-GROUP2-2DRove/assets/92564751/713eb734-44c6-4a51-8016-1c1957938383)
Here is how the generation looks overall. 

![image](https://github.com/UNLV-CS472-672/2024-S-GROUP2-2DRove/assets/92564751/5ded4e16-8eb6-449e-90d2-59357d826d16)
Here is where we have a bit of an issue and why I'm opening a PR rather than making a direct commit. You can see that it is generating tilemap colliders under our main map which inhibits the player characters movement. I am going to play around with the tilemaps to see if we can resolve this issue. 