### PR TITLE
Fixed overlapping tiles issue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,49 @@
+name: 2DRove CI workflow
+
+on:
+  # Replace with whatever branch you're working on :)
+  push: 
+    branches: 
+      - mapgen
+  pull_request:
+    branches:
+      - mapgen
+
+jobs:
+  runTests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout repo code
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      # Caches information to make future jobs go faster
+      - name: Cache Library
+        uses: actions/cache@v2
+        with:
+          path: Library
+          key: Library
+      # Runs tests using integrated Test Runner for workflows
+      - name: Unity - Test runner
+        uses: game-ci/unity-test-runner@v4.1.1
+        # Need to generate Pro Unity license with Github secrets to get this to work   
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        with:
+          projectPath: 2DRove
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          unityVersion: 2022.3.19f1
+          testMode: playmode
+          customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateHtmlReport
+      # Archive our code coverage results in a zip file (will try to output it to actions later)
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: 2DRove/CodeCoverage
+            

--- a/2DRove/Assets/Scripts/MapGenDLA.cs
+++ b/2DRove/Assets/Scripts/MapGenDLA.cs
@@ -39,7 +39,7 @@ namespace MapGenDLANamespace
             borderPositions.Clear();
             tileObjects.Clear();
             //checks for SerializeFields
-            int possibleTiles = Mathf.Abs(maxX-minX+1) * Mathf.Abs(maxY-minY+1);
+            int possibleTiles = (Mathf.Abs(maxX-minX+1) * Mathf.Abs(maxY-minY+1))/2+1;
             if(possibleTiles < tileNum){
                 Debug.LogError("Cannot request more tiles than available");
                 return;
@@ -171,16 +171,18 @@ namespace MapGenDLANamespace
         }
 
         private Vector2Int UpdatePosition(int direction, Vector2Int position, Vector2Int targetPosition)
-        {
+        {   
+            int oldX = position.x;
+            int oldY = position.y;
+            int distance = 1;
+            
             Vector2Int biasDirection = GetBiasDirection(position, targetPosition);
             int bias = Random.Range(0, 10); // Introduce a bias probability, e.g., 20% chance to follow the bias direction
 
             if (bias < 2) // 20% chance to move towards the target
             {
-                return new Vector2Int(
-                    Mathf.Clamp(position.x + biasDirection.x, minX, maxX),
-                    Mathf.Clamp(position.y + biasDirection.y, minY, maxY)
-                );
+                position.x += biasDirection.x;
+                position.y += biasDirection.y;
             }
             else
             {
@@ -189,17 +191,43 @@ namespace MapGenDLANamespace
                     Mathf.Max returns the larger of the two numbers
                     Example: Mathf.Min(5, 10) returns 5
                 */
-                int distance = 1;
+            
                 switch (direction)
                 {
-                    case 0: return new Vector2Int(Mathf.Clamp(position.x + distance,minX, maxX), Mathf.Clamp(position.y + distance, minY, maxY));//ur
-                    case 1: return new Vector2Int(Mathf.Clamp(position.x - distance, minX, maxX), Mathf.Clamp(position.y - distance, minY, maxY));//dl
-                    case 2: return new Vector2Int(Mathf.Clamp(position.x - distance, minX, maxX), Mathf.Clamp(position.y + distance, minY, maxY));//ul
-                    case 3: return new Vector2Int(Mathf.Clamp(position.x + distance, minX, maxX), Mathf.Clamp(position.y - distance, minY, maxY));//dr
-
+                    case 0: 
+                        // return new Vector2Int(Mathf.Clamp(position.x + distance,minX, maxX), Mathf.Clamp(position.y + distance, minY, maxY));//ur
+                        position.x += distance;
+                        position.y += distance;
+                        break;
+                    case 1:
+                        position.x -= distance;
+                        position.y -= distance;                    
+                        break;
+                        // return new Vector2Int(Mathf.Clamp(position.x - distance, minX, maxX), Mathf.Clamp(position.y - distance, minY, maxY));//dl
+                    case 2: 
+                        // return new Vector2Int(Mathf.Clamp(position.x - distance, minX, maxX), Mathf.Clamp(position.y + distance, minY, maxY));//ul
+                        position.x -= distance;
+                        position.y += distance;
+                        break;
+                    case 3: 
+                        //return new Vector2Int(Mathf.Clamp(position.x + distance, minX, maxX), Mathf.Clamp(position.y - distance, minY, maxY));//dr
+                        position.x += distance;
+                        position.y -= distance;
+                        break;
                     default: return position;
                 }
+            }   
+
+            //if UpdatePosition ends up going out of bounds it is going to return another call of the function and it will keep going
+            //until the next update position gives a location that is not out of bounds
+            if(position.x > maxX || position.x < minX || position.y > maxY || position.y < minY){
+                direction = (direction+1)%4;//it will rotate direction to choose a different area 
+                position.x = oldX;//get the values of x and y before they were changed
+                position.y = oldY;//to stay in place and call the function again
+                return UpdatePosition(direction, position, targetPosition);
             }
+            else
+                return new Vector2Int(position.x, position.y);
 
         }
 


### PR DESCRIPTION
- [ ] **Description**

**This pull request is meant to solve the issue of overlapping tiles existing in the map**

- [ ] **Methods Implemented**

No methods were added but updatePosition was updated. Instead of using a clamp to constrain the position of the tiles, the function remembers the old position of the tile and then moves the tile randomly(with the bias included). If the new position ends up being outside the bounds of minX/maxX/minY/maxY, then it will reset the position of the tile and then call the updatePosition recursively until it moves to a valid coordinate.

With this fix, the amount of tiles possible decreases since it is not possible to overlap tiles. I changed the start() function's tile check to properly check the right amount of tiles.

- [ ] **Fields Implmented**
none

- [ ] **Changes to Unity Editor (Screenshots, if applicable)**
none

- [ ] **Related Issue**

is the fix for issue #61 

- [ ] **Mention Reviewers**
@SwiftNemesis 
@cozloff 

- [ ] **Miscellaneous & Images**
none
