### PR TITLE
Fix Fox issue - Animations not transitioning properly

### DIFF
--- a/2DRove/Assets/Animations/Fox/BlueFox/Fox.controller
+++ b/2DRove/Assets/Animations/Fox/BlueFox/Fox.controller
@@ -292,7 +292,7 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
-  m_ExitTime: 0
+  m_ExitTime: 0.75
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0

--- a/2DRove/Assets/Animations/Fox/RedFox/RedFox.controller
+++ b/2DRove/Assets/Animations/Fox/RedFox/RedFox.controller
@@ -233,7 +233,7 @@ AnimatorStateTransition:
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
   m_ExitTime: 0.57142854
-  m_HasExitTime: 1
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -304,9 +304,6 @@ AnimatorStateTransition:
     m_EventTreshold: 0
   - m_ConditionMode: 1
     m_ConditionEvent: isEating
-    m_EventTreshold: 0
-  - m_ConditionMode: 2
-    m_ConditionEvent: isAlert
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -1180991296394736737}
@@ -546,7 +543,7 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
-  m_ExitTime: 0
+  m_ExitTime: 0.75
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0

--- a/2DRove/Assets/Prefabs/BlueFox.prefab
+++ b/2DRove/Assets/Prefabs/BlueFox.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 6133631523922409274}
   - component: {fileID: 8550224772726086128}
   - component: {fileID: 1580194319203663484}
-  m_Layer: 7
+  m_Layer: 3
   m_Name: BlueFox
   m_TagString: Enemy
   m_Icon: {fileID: 0}

--- a/2DRove/Assets/Prefabs/RedFox.prefab
+++ b/2DRove/Assets/Prefabs/RedFox.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5895153965560817016}
   - component: {fileID: 4177119931783376245}
   - component: {fileID: 1406532370408335007}
-  m_Layer: 7
+  m_Layer: 3
   m_Name: RedFox
   m_TagString: Enemy
   m_Icon: {fileID: 0}

--- a/2DRove/Assets/Scripts/Gameplay Scripts/StateMachines/FoxFSM/FoxFleeState.cs
+++ b/2DRove/Assets/Scripts/Gameplay Scripts/StateMachines/FoxFSM/FoxFleeState.cs
@@ -4,7 +4,7 @@ public class FoxFleeState : FoxBaseState
 {
     private Transform player;
     private float fleeSpeed = 5.5f; // Speed at which the fox moves when fleeing
-    private float fleeDuration = 1.5f; // Duration of the flee action
+    private float fleeDuration = 3.0f; // Duration of the flee action
     private float fleeTimer;
 
     public override void EnterState(FoxStateManager fox)
@@ -39,6 +39,7 @@ public class FoxFleeState : FoxBaseState
             // Fleeing is over, switch to idle state
             Debug.Log("Fleeing ended, switching to Idle State");
             fox.animator.SetBool("isFleeing", false);
+            fox.animator.SetBool("isAlert", false);
             fox.SwitchState(fox.IdleState);
         }
     }


### PR DESCRIPTION
# Fix Fox issue - Animations not transitioning properly

## Description
The fox had a different layer causing the player to not hit it. Also, fix the issue of it not transitioning properly from fleeing state to eating state.

## Methods Implemented
* Prefab Layer
* FoxFleeState

## Fields Implemented
* Added fox to 'enemy 'layer to be hit
* Change Flee State to include 'isAlert to  false when fleeing

## Issue 
* The Elk, Fox and bomber will to need the ''Player' (Transform) in their State Manager to work properly.

## Mention Reviewers
@Haikp @koyomi7 @voxelit 

