### PR TITLE
Fix Spitter Range attack

### DIFF
--- a/2DRove/Assets/Prefabs/SpitterRangeAttack.prefab
+++ b/2DRove/Assets/Prefabs/SpitterRangeAttack.prefab
@@ -146,7 +146,7 @@ Rigidbody2D:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 384
+    m_Bits: 256
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0


### PR DESCRIPTION
# Fix Spitter Range attack

## Description
Spitter range attack can now damage the player.


## Changes to Unity Editor (Screenshots, if applicable)
Removed exclude player layer from the range attack prefab
![Spitter_range_damage](https://github.com/UNLV-CS472-672/2024-S-GROUP2-2DRove/assets/65990690/1a97a217-1fe4-4c3c-9d2f-a06926cb5318)
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP2-2DRove/assets/65990690/2159c353-e66c-43a8-8867-4f9d98157803)


## Related Issue 
Issue #123

## Mention Reviewers
@koyomi7 @Haikp 

